### PR TITLE
Fix hot reload / hot restart(#9)

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/lib/src/naver_map_options.dart
+++ b/lib/src/naver_map_options.dart
@@ -260,7 +260,10 @@ class NaverMapOptions {
 
   /// 지도 렌더링을 위해 GLSurfaceView대신 TextureView를 사용할지 여부.
   ///
-  /// 기본값은 false입니다.
+  /// 기본값은 debug build에선 true release builde에선 false 입니다.
+  ///
+  /// 이유는 알 수 없지만 hot reload 시 GLSurfaceView를 사용하면 네이버 지도 sdk의 NDK 레벨에서 에러를 내보내며 앱이 죽습니다.
+  /// 또한 hot restart 시엔 지도 객체가 destory된 후 재생성되지 않습니다.
   final bool useTextureView;
 
   /// TextureView를 투명하게 만들지 여부.
@@ -314,7 +317,7 @@ class NaverMapOptions {
     this.logoGravity = AndroidPlatformConstants.noGravity,
     this.logoMargin = EdgeInsets.zero,
     this.fpsLimit = 0,
-    this.useTextureView = false,
+    this.useTextureView = kDebugMode,
     this.translucentTextureSurface = false,
     this.zOrderMediaOverlay = false,
     this.preserveEGLContextOnPause = true,


### PR DESCRIPTION
#9 이슈에 대한 버그 수정.

이유는 알 수 없지만 hot reload 시 GLSurfaceView를 사용하면 네이버 지도 sdk의 NDK 레벨에서 에러를 내보내며 앱이 종료.
또한 hot restart 시엔 지도 객체가 destory된 후 재생성되지 않음.
NaverMapOptions.useTextureView의 기본값을 kDebugMode로 하여 debug build엔 TextureView를 사용하고 release build엔 GLSurfaceView를 사용하도록 변경. Debug / release build 모두 의도되로 값이 들어가는 것 확인.